### PR TITLE
feat: add Consul Argo CD application manifest

### DIFF
--- a/apps/consul.yaml
+++ b/apps/consul.yaml
@@ -1,0 +1,61 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ci
+  namespace: argocd
+spec:
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    repoURL: https://github.com/hashicorp/consul-helm
+    targetRevision: v0.29.0
+    helm:
+      releaseName: ci
+      valuesObject:
+        global:
+          name: consul
+          datacenter: dc1
+        server:
+          replicas: 3
+          bootstrapExpect: 3
+          storage: 10Gi
+          storageClass: gp2
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      app: consul
+                      component: server
+                      release: ci
+                  topologyKey: kubernetes.io/hostname
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 100m
+              memory: 100Mi
+        client:
+          enabled: true
+          tolerations:
+            - key: "worker-node"
+              operator: "Exists"
+              effect: "NoSchedule"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 100m
+              memory: 100Mi
+        ui:
+          enabled: true
+        dns:
+          enabled: true

--- a/apps/consul.yaml
+++ b/apps/consul.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: ci
+  name: consul
   namespace: argocd
 spec:
   destination:


### PR DESCRIPTION
Introduces a new consul.yaml file containing the Argo CD Application manifest for deploying HashiCorp Consul.