### PR TITLE
feat: add external secrets operator

### DIFF
--- a/apps/external-secrets.yaml
+++ b/apps/external-secrets.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets
+  namespace: argocd
+spec:
+  destination:
+    namespace: default
+    server: https://kubernetes.default.svc
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: external-secrets
+    repoURL: https://charts.external-secrets.io
+    targetRevision: 0.12.1
+    helm:
+      valuesObject:
+        serviceAccount:
+          name: "external-secrets"


### PR DESCRIPTION
This should allow us to manage secrets in a somewhat GitOps way. We'll be able to commit references to external secrets hosted in Parameter Store or Secrets Manager.