### PR TITLE
fix: add iam role annotation to service account

### DIFF
--- a/apps/external-secrets.yaml
+++ b/apps/external-secrets.yaml
@@ -20,3 +20,5 @@ spec:
       valuesObject:
         serviceAccount:
           name: "external-secrets"
+          annotations:
+            eks.amazonaws.com/role-arn: arn:aws:iam::495599749247:role/external_secrets-role-ci-dev-green20250110162358914800000001


### PR DESCRIPTION
Without this annotation, the service account is unable to assume the role, and instead attempts to use the Node IAM role.